### PR TITLE
Cleaned up README for release

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,8 @@
+var http = require('http');
+
+var server = http.createServer(function(req, res) {
+  console.log('query', req.query)
+  console.log('headers', req.headers)
+});
+
+server.listen(3000);


### PR DESCRIPTION
Easier to review by looking at the [full changed README](https://github.com/TabDigital/node-strummer-middleware/blob/readme/README.md)
