### PR TITLE
Report groups of errors accurately.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Tabcorp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var validate = sware({
 server.post('/users', validate, controller);
 ```
 
-`strummer-middleware` can validate 3 areas of the request:
+`strummer-middleware` can validate 4 areas of the request:
 
 ```js
 sware({

--- a/index.js
+++ b/index.js
@@ -8,21 +8,34 @@ var AREAS = {
 };
 
 module.exports = function(checks) {
-
     // first validate the middleware options
     validateOptions(checks);
 
     // return actual middleware
     // unwind loop for better performance
     return function(req, res, next) {
-        var err = errorsFrom(checks, req, 'params')
-               || errorsFrom(checks, req, 'query')
-               || errorsFrom(checks, req, 'body')
-               || errorsFrom(checks, req, 'headers')
-               || null;
-        next(err);
-    };
+        var errors = [];
+        var collectedDetails = [];
+        var collectedAreas = [];
 
+        Object.keys(AREAS).forEach(function(area) {
+            var err = errorsFrom(checks, req, area);
+            if (err) {
+                errors.push(err);
+                collectedAreas.push(area);
+                Array.prototype.push.apply(collectedDetails, err.details);
+            }
+        });
+
+        if (errors.length > 1) {
+            var msg = 'There were combined errors in ' + (collectedAreas.join(', ')) + '.';
+            var err = new Error(msg);
+            err.details = collectedDetails;
+            next(err);
+        } else {
+            next(errors[0]);
+        }
+    };
 };
 
 function validateOptions(checks) {
@@ -47,7 +60,7 @@ function isMatcher(check) {
 
 function errorsFrom(checks, req, area) {
     if (checks[area]) {
-        var result = checks[area].match(null, req[area]);
+        var result = checks[area].match(area, req[area]);
         if (result.length > 0) {
             var err = new Error(AREAS[area]);
             err.details = result;


### PR DESCRIPTION
This PR reports all errors across the request in one error object.

I think we should consider handling header errors differently to the other errors. It is often the case that you will want to represent client side errors in a UI in a form context. Header errors relate to another sort of error - for e.g. a client seeing 'tabcorpauth header is missing' won't be able to do much on a HTML form.

Currently, the `err.details` field is an array that collects all the validation messages. We could discuss making the details an object instead resembling:

```
err.details.combined = [queryError1, bodyErr1, bodyErr2, headerErr1];
err.details.query = [queryError1];
err.details.body = [bodyErr1, bodyErr2];
err.details.header = [headerErr1];
```

This might be more useful for end users.
