### PR TITLE
relax the isMatcher check to allow extra arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function validateOptions(checks) {
 
 function isMatcher(check) {
     var fn = check.match;
-    return fn && (typeof fn === 'function') && (fn.length === 1 || fn.length === 2);
+    return fn && (typeof fn === 'function') && (fn.length >= 1);
 }
 
 function errorsFrom(checks, req, area) {


### PR DESCRIPTION
re https://github.com/Tabcorp/strummer/pull/108

This should fix the bug introduced above.
Not sure if there is any downside to allowing an indefinite amount?